### PR TITLE
FIX: Prevent to give expirience to task when it marked as completed

### DIFF
--- a/eco-core/core-plugin/src/main/kotlin/com/willfp/ecoquests/tasks/Task.kt
+++ b/eco-core/core-plugin/src/main/kotlin/com/willfp/ecoquests/tasks/Task.kt
@@ -146,6 +146,11 @@ class Task(
      * Give experience directly
      */
     fun giveExperience(player: Player, amount: Double) {
+
+        if (player.profile.read(hasCompletedKey)) {
+            return
+        }
+
         val requiredXp = getExperienceRequired(player)
         val newXp = player.profile.read(xpKey) + amount
 


### PR DESCRIPTION
Hi!

Previous version contains a bug that makes the `on-complete` specified in `task` inoperable. 
Every time when player gains experience, the completion of the task is calculated, even if it is marked completed. Because of this, for me, `on-complete` is executed every time. 

Steps to reproduce:

1. Add task `kill_zombie.yml`

```
description: "&fKill zombies (&a%xp%&8/&a%required-xp%&f)"

xp-gain-methods:
  - trigger: kill
    value: 1
    filters:
      entities:
        - zombie

on-complete:
  - id: send_message
    args:
      message: "&a&l[✔] Task done: &r&fKill zombies"
```

2. Add quest `test.yml`

```
name: "Test"
description: ""
gui:
  enabled: true 
  always: true 
  item: dirt
reset-time: -1
tasks:
  - task: kill_zombie
    xp: 3
task-amount: -1
reward-messages:
  - " &8» &r&f+2 %ecoskills_defense_name%"
rewards: [ ]
announce-start: true
start-effects: [ ]
start-conditions: []
auto-start: true
```

3. Kill 3 zombie. After that you should get `[✔] Task done: Kill zombies` message.
4. Kill one more zombie. You get  `[✔] Task done: Kill zombies` message, what shouldn't happen.

My PR fixes this issue.