### PR TITLE
FEAT: Add addexp subcommand

### DIFF
--- a/eco-core/core-plugin/src/main/kotlin/com/willfp/ecoquests/commands/CommandAddExp.kt
+++ b/eco-core/core-plugin/src/main/kotlin/com/willfp/ecoquests/commands/CommandAddExp.kt
@@ -1,0 +1,83 @@
+package com.willfp.ecoquests.commands
+
+import com.willfp.eco.core.EcoPlugin
+import com.willfp.eco.core.command.impl.PluginCommand
+import com.willfp.eco.core.commands.notifyNull
+import com.willfp.eco.util.StringUtils
+import com.willfp.ecoquests.quests.Quests
+import com.willfp.ecoquests.tasks.Tasks
+import org.bukkit.command.CommandSender
+import org.bukkit.util.StringUtil
+
+class CommandAddExp(plugin: EcoPlugin) : PluginCommand(
+    plugin,
+    "addexp",
+    "ecoquests.command.addexp",
+    false
+) {
+
+    override fun onExecute(sender: CommandSender, args: List<String>) {
+        val player = notifyPlayerRequired(args.getOrNull(0), "invalid-player")
+        val quest = notifyNull(Quests[args.getOrNull(1)], "invalid-quest")
+
+        val taskTemplate = notifyNull(Tasks[args.getOrNull(2)], "invalid-task")
+        val task = notifyNull(quest.getTask(taskTemplate), "invalid-task")
+        if (args.size < 4) {
+            sender.sendMessage(plugin.langYml.getMessage("invalid-exp-value"))
+            return
+        }
+
+        val unparsedValue = args[3].notifyNull("invalid-exp-value")
+        val value: Double
+        try {
+            value = unparsedValue.toDouble()
+        } catch (_: NumberFormatException) {
+            sender.sendMessage(plugin.langYml.getMessage("invalid-exp-value"))
+            return
+        }
+
+        task.gainExperience(player, value)
+
+        sender.sendMessage(
+            plugin.langYml.getMessage("exp-added", StringUtils.FormatOption.WITHOUT_PLACEHOLDERS)
+                .replace("%xp%", value.toString())
+                .replace("%quest%", quest.name)
+                .replace("%task%", task.template.id)
+                .replace("%player%", player.name)
+        )
+    }
+
+    override fun tabComplete(sender: CommandSender, args: List<String>): List<String> {
+        val completions = mutableListOf<String>()
+
+        if (args.size == 1) {
+            StringUtil.copyPartialMatches(
+                args[0],
+                plugin.server.onlinePlayers.map { it.name },
+                completions
+            )
+        }
+
+        if (args.size == 2) {
+            StringUtil.copyPartialMatches(
+                args[1],
+                Quests.values().map { it.id },
+                completions
+            )
+        }
+
+        if (args.size == 3) {
+            val quest = Quests[args[1]]
+            if (quest != null) {
+                StringUtil.copyPartialMatches(
+                    args[2],
+                    quest.tasks.map { it.template.id } ,
+                    completions
+                )
+            }
+        }
+
+        return completions
+    }
+
+}

--- a/eco-core/core-plugin/src/main/kotlin/com/willfp/ecoquests/commands/CommandEcoQuests.kt
+++ b/eco-core/core-plugin/src/main/kotlin/com/willfp/ecoquests/commands/CommandEcoQuests.kt
@@ -15,6 +15,7 @@ class CommandEcoQuests(plugin: EcoPlugin) : PluginCommand(
             .addSubcommand(CommandStart(plugin))
             .addSubcommand(CommandResetPlayer(plugin))
             .addSubcommand(CommandReset(plugin))
+            .addSubcommand(CommandAddExp(plugin))
     }
 
     override fun onExecute(sender: CommandSender, args: List<String>) {

--- a/eco-core/core-plugin/src/main/resources/lang.yml
+++ b/eco-core/core-plugin/src/main/resources/lang.yml
@@ -7,12 +7,15 @@ messages:
 
   invalid-player: "&cInvalid player!"
   invalid-quest: "&cInvalid quest!"
+  invalid-task: "&cInvalid task! Should be exist in quest."
+  invalid-exp-value: "&cInvalid exp value! Should be a double (like 1.0)."
   already-started: "&cThe player has already started this quest!"
 
   started-quest: "&fStarted the &a%quest% &fquest for &a%player%&f!"
   reset-quest-for-player: "&fReset the &a%quest% &fquest for &a%player%&f!"
   reset-quest: "&fReset the &a%quest% &fquest!"
   quest-not-resettable: "&cThis quest is not resettable!"
+  exp-added: "&aAdded &f%xp% &aXP in quest &f%quest%&a, task &f%task%&a for &f%player%&a!"
 
 time-since:
   never: "&cNot started yet!"

--- a/eco-core/core-plugin/src/main/resources/plugin.yml
+++ b/eco-core/core-plugin/src/main/resources/plugin.yml
@@ -55,3 +55,6 @@ permissions:
   ecoquests.command.resetplayer:
     description: Allows using /ecoquests resetplayer.
     default: op
+  ecoquests.command.addexp:
+    description: Allows using /ecoquests addexp.
+    default: op

--- a/eco-core/core-plugin/src/main/resources/plugin.yml
+++ b/eco-core/core-plugin/src/main/resources/plugin.yml
@@ -35,6 +35,7 @@ permissions:
       ecoquests.command.start: true
       ecoquests.command.reset: true
       ecoquests.command.resetplayer: true
+      ecoquests.command.addexp: true
 
   ecoquests.command.reload:
     description: Allows reloading the config


### PR DESCRIPTION
Hi!

I've added `addexp` subcommand to manually add experience for a quest task. 
This can be useful for manually test `on_complete` and changing the required XP in tasks that have already started, but their xp requirements have been changed.