### PR TITLE
feat: click-to-start quest icons in GUI

### DIFF
--- a/eco-core/core-plugin/src/main/kotlin/com/willfp/ecoquests/quests/Quest.kt
+++ b/eco-core/core-plugin/src/main/kotlin/com/willfp/ecoquests/quests/Quest.kt
@@ -6,6 +6,8 @@ import com.willfp.eco.core.data.ServerProfile
 import com.willfp.eco.core.data.keys.PersistentDataKey
 import com.willfp.eco.core.data.keys.PersistentDataKeyType
 import com.willfp.eco.core.data.profile
+import com.willfp.eco.core.gui.menu.Menu
+import com.willfp.eco.core.gui.onLeftClick
 import com.willfp.eco.core.gui.slot
 import com.willfp.eco.core.items.Items
 import com.willfp.eco.core.items.builder.modify
@@ -62,6 +64,18 @@ class Quest(
                 startConditions.getNotMetLines(player.toDispatcher(), EmptyProvidedHolder)
             )
 
+            if (
+                plugin.configYml.getBool("gui.click-to-start") &&
+                isStartableBy(player)
+            ) {
+                addLoreLines(
+                    addPlaceholdersInto(
+                        plugin.configYml.getStrings("quests.icon.click-to-start-lore"),
+                        player
+                    )
+                )
+            }
+
             setDisplayName(
                 addPlaceholdersInto(
                     listOf(plugin.configYml.getString("quests.icon.name")),
@@ -70,7 +84,9 @@ class Quest(
             )
         }
     }) {
-
+        onLeftClick { player, _, _, menu ->
+            tryStartFromGui(player, menu)
+        }
     }
 
     val showsInGui = config.getBool("gui.enabled")
@@ -309,6 +325,40 @@ class Quest(
         for (task in tasks) {
             task.reset(player)
         }
+    }
+
+    fun isStartableBy(player: Player): Boolean {
+        return !hasCompleted(player) && !hasStarted(player) && meetsStartConditions(player)
+    }
+
+    fun tryStartFromGui(player: Player, menu: Menu) {
+        if (!plugin.configYml.getBool("gui.click-to-start")) {
+            return
+        }
+
+        if (hasCompleted(player)) {
+            player.sendMessage(plugin.langYml.getMessage("cannot-start-completed"))
+            return
+        }
+
+        if (hasStarted(player)) {
+            player.sendMessage(plugin.langYml.getMessage("already-started"))
+            return
+        }
+
+        if (!meetsStartConditions(player)) {
+            player.sendMessage(plugin.langYml.getMessage("cannot-start-conditions"))
+            return
+        }
+
+        start(player)
+
+        player.sendMessage(
+            plugin.langYml.getMessage("started-quest-self")
+                .replace("%quest%", name)
+        )
+
+        menu.refresh(player)
     }
 
     fun start(player: Player) {

--- a/eco-core/core-plugin/src/main/resources/config.yml
+++ b/eco-core/core-plugin/src/main/resources/config.yml
@@ -15,6 +15,9 @@ gui:
 
   rows: 6
 
+  # If true, players can left-click a quest icon in this GUI to start that quest.
+  click-to-start: true
+
   mask:
     # The way the mask works is by having a list of materials
     # And then a pattern to use those materials.
@@ -157,6 +160,13 @@ quests:
       - " %rewards%"
       - ""
       - "%time_since%"
+
+    # Lore lines appended to the icon when the quest is currently startable
+    # (not started, not completed, start-conditions met, click-to-start enabled).
+    # Set to [] to disable the hint.
+    click-to-start-lore:
+      - ""
+      - "&eClick to start!"
 
   complete:
     message:

--- a/eco-core/core-plugin/src/main/resources/lang.yml
+++ b/eco-core/core-plugin/src/main/resources/lang.yml
@@ -10,6 +10,9 @@ messages:
   invalid-task: "&cInvalid task! Should be exist in quest."
   invalid-exp-value: "&cInvalid exp value! Should be a double (like 1.0)."
   already-started: "&cThe player has already started this quest!"
+  started-quest-self: "&aYou started the &f%quest% &aquest!"
+  cannot-start-conditions: "&cYou don't meet the requirements to start this quest!"
+  cannot-start-completed: "&cYou've already completed this quest!"
 
   started-quest: "&fStarted the &a%quest% &fquest for &a%player%&f!"
   reset-quest-for-player: "&fReset the &a%quest% &fquest for &a%player%&f!"


### PR DESCRIPTION
**Summary**

Players can now left-click a quest icon in /quests to start it directly, avoiding the need to run /ecoquests start. Globally toggled via gui.click-to-start in config.yml (default true). Shows a configurable hint lore when the quest is startable, and refreshes the menu in place after a successful start.

**Testing**
- click-to-start: true in config, open /quests — startable quest shows "Click to start!" lore hint
- Left-click startable quest → chat confirmation, GUI refreshes, hint disappears
- Left-click already-started quest → red error message
- Left-click already-completed quest → red error message
- Left-click quest with unmet conditions → red error, hint not shown on icon
- Set click-to-start: false, reload → no hint shown, clicking does nothing
- Set click-to-start-lore: [], reload → no hint but click still starts the quest
- /ecoquests start <player> <quest> still works normally
