### PR TITLE
feat: Add /quests cancel <quest_name> command

### DIFF
--- a/eco-core/core-plugin/src/main/kotlin/com/willfp/ecoquests/commands/CommandCancel.kt
+++ b/eco-core/core-plugin/src/main/kotlin/com/willfp/ecoquests/commands/CommandCancel.kt
@@ -1,0 +1,47 @@
+package com.willfp.ecoquests.commands
+
+import com.willfp.eco.core.command.impl.PluginCommand
+import com.willfp.eco.util.StringUtils
+import com.willfp.ecoquests.plugin
+import com.willfp.ecoquests.quests.Quests
+import org.bukkit.command.CommandSender
+import org.bukkit.entity.Player
+import org.bukkit.util.StringUtil
+
+object CommandCancel : PluginCommand(
+    plugin,
+    "cancel",
+    "ecoquests.command.quests.cancel",
+    true
+) {
+    override fun onExecute(sender: CommandSender, args: List<String>) {
+        val player = sender as Player
+        val quest = notifyNull(Quests[args.getOrNull(0)], "invalid-quest")
+
+        if (!quest.hasActive(player)) {
+            sender.sendMessage(plugin.langYml.getMessage("quest-not-active"))
+            return
+        }
+
+        quest.reset(player)
+
+        sender.sendMessage(
+            plugin.langYml.getMessage("cancelled-quest", StringUtils.FormatOption.WITHOUT_PLACEHOLDERS)
+                .replace("%quest%", quest.name)
+        )
+    }
+
+    override fun tabComplete(sender: CommandSender, args: List<String>): List<String> {
+        val completions = mutableListOf<String>()
+
+        if (args.size == 1 && sender is Player) {
+            StringUtil.copyPartialMatches(
+                args[0],
+                Quests.getActiveQuests(sender).map { it.id },
+                completions
+            )
+        }
+
+        return completions
+    }
+}

--- a/eco-core/core-plugin/src/main/kotlin/com/willfp/ecoquests/commands/CommandQuests.kt
+++ b/eco-core/core-plugin/src/main/kotlin/com/willfp/ecoquests/commands/CommandQuests.kt
@@ -11,6 +11,10 @@ object CommandQuests : PluginCommand(
     "ecoquests.command.quests",
     true
 ) {
+    init {
+        this.addSubcommand(CommandCancel)
+    }
+
     override fun getAliases(): List<String> {
         return listOf(
             "q",

--- a/eco-core/core-plugin/src/main/resources/lang.yml
+++ b/eco-core/core-plugin/src/main/resources/lang.yml
@@ -18,6 +18,8 @@ messages:
   reset-quest-for-player: "&fReset the &a%quest% &fquest for &a%player%&f!"
   reset-quest: "&fReset the &a%quest% &fquest!"
   quest-not-resettable: "&cThis quest is not resettable!"
+  quest-not-active: "&cYou don't have this quest active!"
+  cancelled-quest: "&aYou cancelled the &f%quest% &aquest!"
   exp-added: "&aAdded &f%xp% &aXP in quest &f%quest%&a, task &f%task%&a for &f%player%&a!"
 
 time-since:

--- a/eco-core/core-plugin/src/main/resources/lang.yml
+++ b/eco-core/core-plugin/src/main/resources/lang.yml
@@ -18,7 +18,7 @@ messages:
   reset-quest-for-player: "&fReset the &a%quest% &fquest for &a%player%&f!"
   reset-quest: "&fReset the &a%quest% &fquest!"
   quest-not-resettable: "&cThis quest is not resettable!"
-  quest-not-active: "&cYou don't have this quest active!"
+  quest-not-active: "&cYou have not started this quest!"
   cancelled-quest: "&aYou cancelled the &f%quest% &aquest!"
   exp-added: "&aAdded &f%xp% &aXP in quest &f%quest%&a, task &f%task%&a for &f%player%&a!"
 

--- a/eco-core/core-plugin/src/main/resources/plugin.yml
+++ b/eco-core/core-plugin/src/main/resources/plugin.yml
@@ -32,6 +32,7 @@ permissions:
     children:
       ecoquests.command.reload: true
       ecoquests.command.quests: true
+      ecoquests.command.quests.cancel: true
       ecoquests.command.start: true
       ecoquests.command.reset: true
       ecoquests.command.resetplayer: true
@@ -45,6 +46,9 @@ permissions:
     default: true
   ecoquests.command.quests:
     description: Allows the use of /quests.
+    default: true
+  ecoquests.command.quests.cancel:
+    description: Allows using /quests cancel.
     default: true
   ecoquests.command.start:
     description: Allows using /ecoquests start.


### PR DESCRIPTION
Hi!

I've added a cancel subcommand to `/quests` that lets players cancel one of their active quests, resetting all progress on it.

Tab-completion shows only the quests the player currently has active.

This is especially useful in a scenario where a player is limited in how many quests they can have active at once, with this subcommand players can drop a difficult quest to make room for an easier one.