### PR TITLE
fix: Admonition format

### DIFF
--- a/documentation/ecoquests/how-to-make-a-quest.md
+++ b/documentation/ecoquests/how-to-make-a-quest.md
@@ -1,4 +1,4 @@
----
+﻿---
 title: How to make a Quest
 sidebar_position: 1
 ---
@@ -70,7 +70,7 @@ task-amount: -1
 ```
 
 ### The Rewards Section
-:::dangerEffects Section
+:::danger Effects Section
 
 The rewards section uses the effects system. You can configure effects, conditions, filters, and mutators in this section to run when the quest is completed.
 
@@ -94,7 +94,7 @@ rewards:
 ```
 
 ### The Quest Start Section
-:::dangerEffects Section
+:::danger Effects Section
 
 The start section uses the effects system. You can configure effects, conditions, filters, and mutators in this section to run when the quest is started.
 

--- a/documentation/ecoquests/how-to-make-a-task.md
+++ b/documentation/ecoquests/how-to-make-a-task.md
@@ -1,4 +1,4 @@
----
+﻿---
 title: How to make a Task
 sidebar_position: 2
 ---
@@ -53,7 +53,7 @@ xp-gain-methods:
 ```
 
 ### The On-Complete Effects Section
-:::dangerEffects Section
+:::danger Effects Section
 
 The effects section is the core functionality of the task. You can configure effects, conditions, filters, and mutators in this section to run when the task is completed.
 


### PR DESCRIPTION
Fixes missing space between admonition type and title in documentation (e.g. `:::dangerEffects Section` → `:::danger Effects Section`).