### PR TITLE
feat: Add max active quests limit via permission and config

### DIFF
--- a/eco-core/core-plugin/src/main/kotlin/com/willfp/ecoquests/EcoQuestsPlugin.kt
+++ b/eco-core/core-plugin/src/main/kotlin/com/willfp/ecoquests/EcoQuestsPlugin.kt
@@ -92,7 +92,7 @@ class EcoQuestsPlugin : LibreforgePlugin() {
         this.scheduler.runTimer(scanInterval, scanInterval) {
             for (quest in Quests.values()) {
                 for (player in Bukkit.getOnlinePlayers()) {
-                    if (quest.shouldStart(player)) {
+                    if (quest.shouldStart(player) && !Quests.hasReachedMaxActiveQuests(player)) {
                         quest.start(player)
                     }
                 }

--- a/eco-core/core-plugin/src/main/kotlin/com/willfp/ecoquests/quests/Quest.kt
+++ b/eco-core/core-plugin/src/main/kotlin/com/willfp/ecoquests/quests/Quest.kt
@@ -329,6 +329,7 @@ class Quest(
 
     fun isStartableBy(player: Player): Boolean {
         return !hasCompleted(player) && !hasStarted(player) && meetsStartConditions(player)
+            && !Quests.hasReachedMaxActiveQuests(player)
     }
 
     fun tryStartFromGui(player: Player, menu: Menu) {
@@ -348,6 +349,11 @@ class Quest(
 
         if (!meetsStartConditions(player)) {
             player.sendMessage(plugin.langYml.getMessage("cannot-start-conditions"))
+            return
+        }
+
+        if (Quests.hasReachedMaxActiveQuests(player)) {
+            player.sendMessage(plugin.langYml.getMessage("max-active-quests"))
             return
         }
 

--- a/eco-core/core-plugin/src/main/kotlin/com/willfp/ecoquests/quests/Quests.kt
+++ b/eco-core/core-plugin/src/main/kotlin/com/willfp/ecoquests/quests/Quests.kt
@@ -2,6 +2,7 @@ package com.willfp.ecoquests.quests
 
 import com.willfp.eco.core.config.interfaces.Config
 import com.willfp.eco.core.registry.Registry
+import com.willfp.ecoquests.plugin
 import com.willfp.libreforge.loader.LibreforgePlugin
 import com.willfp.libreforge.loader.configs.ConfigCategory
 import org.bukkit.entity.Player
@@ -37,6 +38,24 @@ object Quests : ConfigCategory("quest", "quests") {
     fun getCompletedQuests(player: Player): List<Quest> {
         return values()
             .filter { it.hasCompleted(player) }
+    }
+
+    fun getMaxActiveQuests(player: Player): Int {
+        var permissionMax: Int? = null
+        for (info in player.effectivePermissions) {
+            if (!info.value) continue
+            val value = info.permission
+                .removePrefix("ecoquests.quests.max.")
+                .takeIf { info.permission.startsWith("ecoquests.quests.max.") }
+                ?.toIntOrNull() ?: continue
+            if (permissionMax == null || value > permissionMax!!) permissionMax = value
+        }
+        return permissionMax ?: plugin.configYml.getInt("max-active-quests")
+    }
+
+    fun hasReachedMaxActiveQuests(player: Player): Boolean {
+        val max = getMaxActiveQuests(player)
+        return max != -1 && getActiveQuests(player).size >= max
     }
 
     fun getShownCompletedQuests(player: Player): List<Quest> {

--- a/eco-core/core-plugin/src/main/resources/config.yml
+++ b/eco-core/core-plugin/src/main/resources/config.yml
@@ -10,6 +10,11 @@ use-local-storage: false
 
 scan-interval: 20 # How often to scan for quests auto-starting (in ticks)
 
+# The default maximum number of active quests a player can have at once.
+# -1 means unlimited.
+# Override per-player or per-group with ecoquests.quests.max.<number> permission.
+max-active-quests: -1
+
 gui:
   title: "Quest Book"
 

--- a/eco-core/core-plugin/src/main/resources/lang.yml
+++ b/eco-core/core-plugin/src/main/resources/lang.yml
@@ -13,6 +13,7 @@ messages:
   started-quest-self: "&aYou started the &f%quest% &aquest!"
   cannot-start-conditions: "&cYou don't meet the requirements to start this quest!"
   cannot-start-completed: "&cYou've already completed this quest!"
+  max-active-quests: "&cYou have reached the maximum number of active quests!"
 
   started-quest: "&fStarted the &a%quest% &fquest for &a%player%&f!"
   reset-quest-for-player: "&fReset the &a%quest% &fquest for &a%player%&f!"


### PR DESCRIPTION
Following the idea behind #14, with this PR I'm now adding the possibility of limiting how many quests a player can have started at once. This is now possible since players can cancel their quests in favor of other ones. 

A little summary:
- Adds a `max-active-quests` config option (default -1 = unlimited) to cap how many quests a player can have active at once
- Adds support for the `ecoquests.quests.max.<number>` permission node to override the config limit per-player or per-group. If multiple permissions match, the highest value wins
- Blocks quest starts from the GUI, auto-start, and shows a configurable `max-active-quests` lang message when the limit is reached
- The "Click to start!" hint in the quest GUI is also suppressed when a player is at their limit

Everything has been tested and seems to be working correctly. 